### PR TITLE
No longer build appx with WSAPlayer by default

### DIFF
--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UnityPlayerBuildTools.cs
@@ -163,7 +163,7 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
                 switch (EditorUserBuildSettings.activeBuildTarget)
                 {
                     case BuildTarget.WSAPlayer:
-                        success = await UwpPlayerBuildTools.BuildPlayer(new UwpBuildInfo(true) { BuildAppx = true });
+                        success = await UwpPlayerBuildTools.BuildPlayer(new UwpBuildInfo(true));
                         break;
                     default:
                         var buildInfo = new BuildInfo(true) as IBuildInfo;

--- a/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
+++ b/Assets/MixedRealityToolkit/Utilities/BuildAndDeploy/UwpBuildInfo.cs
@@ -9,7 +9,6 @@ namespace Microsoft.MixedReality.Toolkit.Build.Editor
     {
         public UwpBuildInfo(bool isCommandLine = false) : base(isCommandLine)
         {
-            BuildPlatform = "x86";
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Also removed build platform defaulting to x86 for uwp builds.

Overview
---


Changes
---
- Fixes: # .
